### PR TITLE
feat(user): create user schema

### DIFF
--- a/mv-openapi.yaml
+++ b/mv-openapi.yaml
@@ -16,8 +16,8 @@ servers:
 paths:
   /polls:
     get:
-      operationId: get-polls
-      summary: Gets all polls.
+      operationId: get-users
+      summary: Gets all users.
       responses:
         '200':
           description: OK
@@ -26,16 +26,16 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/poll'
+                  $ref: '#/components/schemas/user'
     post:
-      operationId: create-poll
-      summary: Creates a poll.
+      operationId: create-user
+      summary: Creates an user
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/poll'
+              $ref: '#/components/schemas/user'
       responses:
         '201':
           description: Created
@@ -46,20 +46,14 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: Id of the created poll.
+                    description: Id of the created user.
           links:
-            get-poll:
-              $ref: '#/components/links/get-poll'
-            update-poll:
-              $ref: '#/components/links/update-poll'
-            delete-poll:
-              $ref: '#/components/links/delete-poll'
-            create-ballot:
-              $ref: '#/components/links/create-ballot'
-            list-poll-results:
-              $ref: '#/components/links/list-poll-results'
-        '400':
-          description: Bad Request. Expect at least 2 proposals and a title.
+            get-user:
+              $ref: '#/components/links/get-user'
+            update-user:
+              $ref: '#/components/links/update-user'
+            delete-user:
+              $ref: '#/components/links/delete-user'
   '/polls/{poll-id}':
     parameters:
       - in: path
@@ -253,6 +247,103 @@ paths:
                 $ref: '#/components/schemas/result'
         '404':
           $ref: '#/components/responses/poll-not-found'
+  /users:
+    get:
+      operationId: get-polls
+      summary: Gets all polls.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/poll'
+    post:
+      operationId: create-poll
+      summary: Creates a poll.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/poll'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: Id of the created poll.
+          links:
+            get-poll:
+              $ref: '#/components/links/get-poll'
+            update-poll:
+              $ref: '#/components/links/update-poll'
+            delete-poll:
+              $ref: '#/components/links/delete-poll'
+            create-ballot:
+              $ref: '#/components/links/create-ballot'
+            list-poll-results:
+              $ref: '#/components/links/list-poll-results'
+        '400':
+          description: Bad Request. Expect at least 2 proposals and a title.
+  '/users/{user-id}':
+    parameters:
+      - in: path
+        name: user-id
+        required: true
+        schema:
+          type: integer
+          format: int64
+    get:
+      operationId: get-user
+      summary: Gets a user by ID
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/user'
+        '404':
+          $ref: '#/components/responses/user-not-found'
+    patch:
+      operationId: update-user
+      summary: Updates a user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/user'
+      security:
+        - {}
+        - userAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/user'
+    delete:
+      operationId: delete-user
+      summary: Deletes a user
+      responses:
+        '200':
+          description: OK
+        '404':
+          $ref: '#/components/responses/user-not-found'
+      security:
+        - userAuth: []
 components:
   securitySchemes:
     participantAuth:
@@ -264,7 +355,28 @@ components:
     resultAuth:
       type: http
       scheme: bearer
+    userAuth:
+      type: http
+      scheme: bearer
   schemas:
+    user:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: A unique identifier
+          example: 0
+          readOnly: true
+        name:
+          type: string
+          description: Unique user-name
+          example: john.doe
+        description:
+          type: string
+          description: An optional description of the user
+          example: >-
+            John Doe is a multiple-use name that is used when the true name of a
+            person is unknown or is being intentionally concealed
     ballot:
       type: object
       properties:
@@ -296,6 +408,10 @@ components:
           description: The ballots received by this proposal.
           items:
             $ref: '#/components/schemas/ballot'
+        description:
+          type: string
+          description: An optional description of the proposal
+          example: This school would welcome 500 pupils.
     mention:
       type: object
       properties:
@@ -310,6 +426,10 @@ components:
             Unique but short name of the mention, like "Excellent" or "To
             reject".
           example: Excellent
+        description:
+          type: string
+          description: An optional description of the mention
+          example: 'In this poll, the mention "To reject" disqualifies the proposal.'
     participant:
       type: object
       properties:
@@ -318,6 +438,10 @@ components:
           description: A unique identifier
           example: JtRm05yjMAuFCI2uwnFp
           readOnly: true
+        description:
+          type: string
+          description: An optional description of the participant
+          example: John Doe
         has-participed:
           type: boolean
           description: >-
@@ -329,7 +453,7 @@ components:
           description: The identifier of the poll that the participant participates on.
           example: 1jDe1e5eF_IkaYPuoIYX
         mail:
-          type: object
+          type: string
           description: >-
             The mail that will eventually created at the creation of the
             participant (not kept in memory).
@@ -346,6 +470,10 @@ components:
           type: string
           example: What project should our neighbourhood invest in for the next year?
           description: The title of the poll
+        description:
+          type: string
+          description: A description of the poll
+          example: null
         proposals:
           type: array
           description: The proposals being voted in a poll.
@@ -365,7 +493,10 @@ components:
           description: The participants that are allowed to participate to the election.
           items:
             $ref: '#/components/schemas/participant'
-        restrict_participants:
+        user-id:
+          type: string
+          description: 'Organizer id. If not given, a dummy user is created.'
+        restrict-participants:
           type: boolean
           description: 'True if anyone can participate to this poll, False otherwise.'
           example: false
@@ -406,6 +537,41 @@ components:
             type: integer
             format: int16
   links:
+    get-user:
+      operationId: get-user
+      parameters:
+        userId: $response.body#/id
+      description: >
+        The `id` value returned in the response can be used as the `user-id`
+        parameter in GET /users/{user-id}.
+    update-user:
+      operationId: update-user
+      parameters:
+        userId: $response.body#/id
+      description: >
+        The `id` value returned in the response can be used as the `user-id`
+        parameter in PATCH /users/{user-id}.
+    delete-user:
+      operationId: delete-user
+      parameters:
+        userId: $response.body#/id
+      description: >
+        The `id` value returned in the response can be used as the `user-id`
+        parameter in DELETE /users/{user-id}.
+    get-ballot:
+      operationId: get-ballot
+      parameters:
+        ballotId: $response.body#/id
+      description: >
+        The `id` value returned in the response can be used as the `ballot-id`
+        parameter in GET /polls/{poll-id}/ballots/{ballot-id}.
+    delete-ballot:
+      operationId: delete-ballot
+      parameters:
+        ballotId: $response.body#/id
+      description: >
+        The `id` value returned in the response can be used as the `ballot-id`
+        parameter in DELETE /polls/{poll-id}/ballots/{ballot-id}.
     get-poll:
       operationId: get-poll
       parameters:
@@ -441,20 +607,6 @@ components:
       description: >
         The `id` value returned in the response can be used as the `poll-id`
         parameter in GET /polls/{poll-id}/results.
-    get-ballot:
-      operationId: get-ballot
-      parameters:
-        ballotId: $response.body#/id
-      description: >
-        The `id` value returned in the response can be used as the `ballot-id`
-        parameter in GET /polls/{poll-id}/ballots/{ballot-id}.
-    delete-ballot:
-      operationId: delete-ballot
-      parameters:
-        ballotId: $response.body#/id
-      description: >
-        The `id` value returned in the response can be used as the `ballot-id`
-        parameter in DELETE /polls/{poll-id}/ballots/{ballot-id}.
   responses:
     poll-not-found:
       description: The specified poll was not found
@@ -470,6 +622,12 @@ components:
             $ref: '#/components/schemas/error'
     participant-not-found:
       description: The specified participant was not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error'
+    user-not-found:
+      description: The specified user was not found
       content:
         application/json:
           schema:

--- a/mv-openapi.yaml
+++ b/mv-openapi.yaml
@@ -16,8 +16,8 @@ servers:
 paths:
   /polls:
     get:
-      operationId: get-users
-      summary: Gets all users.
+      operationId: get-polls
+      summary: Gets all polls.
       responses:
         '200':
           description: OK
@@ -26,16 +26,16 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/user'
+                  $ref: '#/components/schemas/poll'
     post:
-      operationId: create-user
-      summary: Creates an user
+      operationId: create-poll
+      summary: Creates a poll.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/user'
+              $ref: '#/components/schemas/poll'
       responses:
         '201':
           description: Created
@@ -46,14 +46,20 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: Id of the created user.
+                    description: Id of the created poll.
           links:
-            get-user:
-              $ref: '#/components/links/get-user'
-            update-user:
-              $ref: '#/components/links/update-user'
-            delete-user:
-              $ref: '#/components/links/delete-user'
+            get-poll:
+              $ref: '#/components/links/get-poll'
+            update-poll:
+              $ref: '#/components/links/update-poll'
+            delete-poll:
+              $ref: '#/components/links/delete-poll'
+            create-ballot:
+              $ref: '#/components/links/create-ballot'
+            list-poll-results:
+              $ref: '#/components/links/list-poll-results'
+        '400':
+          description: Bad Request. Expect at least 2 proposals and a title.
   '/polls/{poll-id}':
     parameters:
       - in: path
@@ -249,8 +255,8 @@ paths:
           $ref: '#/components/responses/poll-not-found'
   /users:
     get:
-      operationId: get-polls
-      summary: Gets all polls.
+      operationId: get-users
+      summary: Gets all users.
       responses:
         '200':
           description: OK
@@ -259,16 +265,16 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/poll'
+                  $ref: '#/components/schemas/user'
     post:
-      operationId: create-poll
-      summary: Creates a poll.
+      operationId: create-user
+      summary: Creates an user
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/poll'
+              $ref: '#/components/schemas/user'
       responses:
         '201':
           description: Created
@@ -279,20 +285,14 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: Id of the created poll.
+                    description: Id of the created user.
           links:
-            get-poll:
-              $ref: '#/components/links/get-poll'
-            update-poll:
-              $ref: '#/components/links/update-poll'
-            delete-poll:
-              $ref: '#/components/links/delete-poll'
-            create-ballot:
-              $ref: '#/components/links/create-ballot'
-            list-poll-results:
-              $ref: '#/components/links/list-poll-results'
-        '400':
-          description: Bad Request. Expect at least 2 proposals and a title.
+            get-user:
+              $ref: '#/components/links/get-user'
+            update-user:
+              $ref: '#/components/links/update-user'
+            delete-user:
+              $ref: '#/components/links/delete-user'
   '/users/{user-id}':
     parameters:
       - in: path
@@ -359,24 +359,6 @@ components:
       type: http
       scheme: bearer
   schemas:
-    user:
-      type: object
-      properties:
-        id:
-          type: integer
-          description: A unique identifier
-          example: 0
-          readOnly: true
-        name:
-          type: string
-          description: Unique user-name
-          example: john.doe
-        description:
-          type: string
-          description: An optional description of the user
-          example: >-
-            John Doe is a multiple-use name that is used when the true name of a
-            person is unknown or is being intentionally concealed
     ballot:
       type: object
       properties:
@@ -423,13 +405,13 @@ components:
         name:
           type: string
           description: >-
-            Unique but short name of the mention, like "Excellent" or "To
-            reject".
+            Unique but short name of the mention, like *Excellent* or *To
+            reject*.
           example: Excellent
         description:
           type: string
           description: An optional description of the mention
-          example: 'In this poll, the mention "To reject" disqualifies the proposal.'
+          example: 'In this poll, the mention *To reject* disqualifies the proposal.'
     participant:
       type: object
       properties:
@@ -536,42 +518,25 @@ components:
           items:
             type: integer
             format: int16
+    user:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: A unique identifier
+          example: 0
+          readOnly: true
+        name:
+          type: string
+          description: Unique user-name
+          example: john.doe
+        description:
+          type: string
+          description: An optional description of the user
+          example: >-
+            John Doe is a multiple-use name that is used when the true name of a
+            person is unknown or is being intentionally concealed
   links:
-    get-user:
-      operationId: get-user
-      parameters:
-        userId: $response.body#/id
-      description: >
-        The `id` value returned in the response can be used as the `user-id`
-        parameter in GET /users/{user-id}.
-    update-user:
-      operationId: update-user
-      parameters:
-        userId: $response.body#/id
-      description: >
-        The `id` value returned in the response can be used as the `user-id`
-        parameter in PATCH /users/{user-id}.
-    delete-user:
-      operationId: delete-user
-      parameters:
-        userId: $response.body#/id
-      description: >
-        The `id` value returned in the response can be used as the `user-id`
-        parameter in DELETE /users/{user-id}.
-    get-ballot:
-      operationId: get-ballot
-      parameters:
-        ballotId: $response.body#/id
-      description: >
-        The `id` value returned in the response can be used as the `ballot-id`
-        parameter in GET /polls/{poll-id}/ballots/{ballot-id}.
-    delete-ballot:
-      operationId: delete-ballot
-      parameters:
-        ballotId: $response.body#/id
-      description: >
-        The `id` value returned in the response can be used as the `ballot-id`
-        parameter in DELETE /polls/{poll-id}/ballots/{ballot-id}.
     get-poll:
       operationId: get-poll
       parameters:
@@ -607,6 +572,41 @@ components:
       description: >
         The `id` value returned in the response can be used as the `poll-id`
         parameter in GET /polls/{poll-id}/results.
+    get-ballot:
+      operationId: get-ballot
+      parameters:
+        ballotId: $response.body#/id
+      description: >
+        The `id` value returned in the response can be used as the `ballot-id`
+        parameter in GET /polls/{poll-id}/ballots/{ballot-id}.
+    delete-ballot:
+      operationId: delete-ballot
+      parameters:
+        ballotId: $response.body#/id
+      description: >
+        The `id` value returned in the response can be used as the `ballot-id`
+        parameter in DELETE /polls/{poll-id}/ballots/{ballot-id}.
+    get-user:
+      operationId: get-user
+      parameters:
+        userId: $response.body#/id
+      description: >
+        The `id` value returned in the response can be used as the `user-id`
+        parameter in GET /users/{user-id}.
+    update-user:
+      operationId: update-user
+      parameters:
+        userId: $response.body#/id
+      description: >
+        The `id` value returned in the response can be used as the `user-id`
+        parameter in PATCH /users/{user-id}.
+    delete-user:
+      operationId: delete-user
+      parameters:
+        userId: $response.body#/id
+      description: >
+        The `id` value returned in the response can be used as the `user-id`
+        parameter in DELETE /users/{user-id}.
   responses:
     poll-not-found:
       description: The specified poll was not found

--- a/mv-openapi.yaml
+++ b/mv-openapi.yaml
@@ -394,6 +394,8 @@ components:
           type: string
           description: An optional description of the proposal
           example: This school would welcome 500 pupils.
+      required:
+        - name
     mention:
       type: object
       properties:
@@ -412,27 +414,33 @@ components:
           type: string
           description: An optional description of the mention
           example: 'In this poll, the mention *To reject* disqualifies the proposal.'
+      required:
+        - name
     participant:
       type: object
       properties:
         id:
           type: string
-          description: A unique identifier
+          description: A unique identifier.
           example: JtRm05yjMAuFCI2uwnFp
           readOnly: true
         description:
           type: string
-          description: An optional description of the participant
+          description: An optional description of the participant.
           example: John Doe
         has-participed:
           type: boolean
           description: >-
             True if the participant already participed to the poll, False
-            otherwise
+            otherwise.
           example: true
         poll-id:
           type: string
           description: The identifier of the poll that the participant participates on.
+          example: 1jDe1e5eF_IkaYPuoIYX
+        user-id:
+          type: string
+          description: The identifier of the user.
           example: 1jDe1e5eF_IkaYPuoIYX
         mail:
           type: string
@@ -440,6 +448,8 @@ components:
             The mail that will eventually created at the creation of the
             participant (not kept in memory).
           example: john-doe@example.com
+      required:
+        - poll-id
     poll:
       type: object
       properties:
@@ -482,6 +492,9 @@ components:
           type: boolean
           description: 'True if anyone can participate to this poll, False otherwise.'
           example: false
+      required:
+        - title
+        - proposals
     error:
       type: object
       properties:
@@ -518,6 +531,9 @@ components:
           items:
             type: integer
             format: int16
+      required:
+        - ranking
+        - poll
     user:
       type: object
       properties:

--- a/openapi/components/links/delete-user.yaml
+++ b/openapi/components/links/delete-user.yaml
@@ -1,0 +1,6 @@
+operationId: 'delete-user'
+parameters:
+  userId: $response.body#/id
+description: >
+  The `id` value returned in the response can be used as the `user-id` parameter
+  in DELETE /users/{user-id}.

--- a/openapi/components/links/get-user.yaml
+++ b/openapi/components/links/get-user.yaml
@@ -1,0 +1,6 @@
+operationId: 'get-user'
+parameters:
+  userId: $response.body#/id
+description: >
+  The `id` value returned in the response can be used as the `user-id` parameter
+  in GET /users/{user-id}.

--- a/openapi/components/links/update-user.yaml
+++ b/openapi/components/links/update-user.yaml
@@ -1,0 +1,6 @@
+operationId: 'update-user'
+parameters:
+  userId: $response.body#/id
+description: >
+  The `id` value returned in the response can be used as the `user-id` parameter
+  in PATCH /users/{user-id}.

--- a/openapi/components/responses/user-not-found.yaml
+++ b/openapi/components/responses/user-not-found.yaml
@@ -1,0 +1,5 @@
+description: The specified user was not found
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/error.yaml

--- a/openapi/components/schemas/mention.yaml
+++ b/openapi/components/schemas/mention.yaml
@@ -13,3 +13,5 @@ properties:
     type: string
     description: An optional description of the mention
     example: In this poll, the mention *To reject* disqualifies the proposal.
+required:
+  - name

--- a/openapi/components/schemas/mention.yaml
+++ b/openapi/components/schemas/mention.yaml
@@ -7,9 +7,9 @@ properties:
     readOnly: true
   name:
     type: string
-    description: Unique but short name of the mention, like "Excellent" or "To reject".
+    description: Unique but short name of the mention, like *Excellent* or *To reject*.
     example: Excellent
   description:
     type: string
     description: An optional description of the mention
-    example: In this poll, the mention "To reject" disqualifies the proposal.
+    example: In this poll, the mention *To reject* disqualifies the proposal.

--- a/openapi/components/schemas/participant.yaml
+++ b/openapi/components/schemas/participant.yaml
@@ -2,22 +2,28 @@ type: object
 properties:
   id:
     type: string
-    description: A unique identifier
+    description: A unique identifier.
     example: JtRm05yjMAuFCI2uwnFp
     readOnly: true
   description:
     type: string
-    description: An optional description of the participant
+    description: An optional description of the participant.
     example: John Doe
   has-participed:
     type: boolean
-    description: True if the participant already participed to the poll, False otherwise
+    description: True if the participant already participed to the poll, False otherwise.
     example: true
   poll-id:
     type: string
     description: The identifier of the poll that the participant participates on.
     example: 1jDe1e5eF_IkaYPuoIYX
+  user-id:
+    type: string
+    description: The identifier of the user.
+    example: 1jDe1e5eF_IkaYPuoIYX
   mail:
     type: string    
     description: The mail that will eventually created at the creation of the participant (not kept in memory).
     example: john-doe@example.com
+required:
+  - poll-id

--- a/openapi/components/schemas/poll.yaml
+++ b/openapi/components/schemas/poll.yaml
@@ -39,3 +39,6 @@ properties:
     type: boolean
     description: True if anyone can participate to this poll, False otherwise.
     example: false
+required:
+  - title
+  - proposals

--- a/openapi/components/schemas/poll.yaml
+++ b/openapi/components/schemas/poll.yaml
@@ -32,7 +32,10 @@ properties:
     description: The participants that are allowed to participate to the election.
     items:
       $ref: ./participant.yaml
-  restrict_participants:
+  user-id:
+    type: string
+    description: Organizer id. If not given, a dummy user is created.
+  restrict-participants:
     type: boolean
     description: True if anyone can participate to this poll, False otherwise.
     example: false

--- a/openapi/components/schemas/proposal.yaml
+++ b/openapi/components/schemas/proposal.yaml
@@ -18,3 +18,5 @@ properties:
     type: string
     description: An optional description of the proposal
     example: This school would welcome 500 pupils.
+required:
+  - name

--- a/openapi/components/schemas/result.yaml
+++ b/openapi/components/schemas/result.yaml
@@ -13,3 +13,6 @@ properties:
     items:
       type: integer
       format: int16
+required:
+  - ranking
+  - poll

--- a/openapi/components/schemas/user.yaml
+++ b/openapi/components/schemas/user.yaml
@@ -1,0 +1,15 @@
+type: object
+properties:
+  id:
+    type: integer
+    description: A unique identifier
+    example: 0
+    readOnly: true
+  name:
+    type: string
+    description: Unique user-name
+    example: john.doe
+  description:
+    type: string
+    description: An optional description of the user
+    example: John Doe is a multiple-use name that is used when the true name of a person is unknown or is being intentionally concealed

--- a/openapi/mv-openapi-root.yaml
+++ b/openapi/mv-openapi-root.yaml
@@ -27,6 +27,10 @@ paths:
     $ref: 'paths/polls@{poll-id}@participants@{participant-id}@.yaml'
   '/polls/{poll-id}/results':
     $ref: 'paths/polls@{poll-id}@results.yaml'
+  /users:
+    $ref: paths/users.yaml
+  '/users/{user-id}':
+    $ref: 'paths/users@{user-id}.yaml'
 components:
   securitySchemes:
     participantAuth:
@@ -36,5 +40,8 @@ components:
       type: http
       scheme: bearer
     resultAuth:
+      type: http
+      scheme: bearer
+    userAuth:
       type: http
       scheme: bearer

--- a/openapi/paths/polls.yaml
+++ b/openapi/paths/polls.yaml
@@ -1,6 +1,6 @@
 get:
-  operationId: get-users
-  summary: Gets all users.
+  operationId: get-polls
+  summary: Gets all polls.
   responses:
     '200':
       description: OK
@@ -9,16 +9,16 @@ get:
           schema:
             type: array
             items:
-              $ref: ../components/schemas/user.yaml
+              $ref: ../components/schemas/poll.yaml
 post:
-  operationId: create-user
-  summary: Creates an user
+  operationId: create-poll
+  summary: Creates a poll.
   requestBody:
     required: true
     content:
       application/json:
         schema:
-          $ref: ../components/schemas/user.yaml
+          $ref: ../components/schemas/poll.yaml
   responses:
     '201':
       description: Created
@@ -29,11 +29,17 @@ post:
             properties:
               id:
                 type: string
-                description: Id of the created user.
+                description: Id of the created poll.
       links:
-        get-user:
-          $ref: ../components/links/get-user.yaml
-        update-user:
-          $ref: ../components/links/update-user.yaml
-        delete-user:
-          $ref: ../components/links/delete-user.yaml
+        get-poll:
+          $ref: ../components/links/get-poll.yaml
+        update-poll:
+          $ref: ../components/links/update-poll.yaml
+        delete-poll:
+          $ref: ../components/links/delete-poll.yaml
+        create-ballot:
+          $ref: ../components/links/create-ballot.yaml
+        list-poll-results:
+          $ref: ../components/links/list-poll-results.yaml
+    '400':
+      description: Bad Request. Expect at least 2 proposals and a title.

--- a/openapi/paths/polls.yaml
+++ b/openapi/paths/polls.yaml
@@ -1,6 +1,6 @@
 get:
-  operationId: get-polls
-  summary: Gets all polls.
+  operationId: get-users
+  summary: Gets all users.
   responses:
     '200':
       description: OK
@@ -9,16 +9,16 @@ get:
           schema:
             type: array
             items:
-              $ref: ../components/schemas/poll.yaml
+              $ref: ../components/schemas/user.yaml
 post:
-  operationId: create-poll
-  summary: Creates a poll.
+  operationId: create-user
+  summary: Creates an user
   requestBody:
     required: true
     content:
       application/json:
         schema:
-          $ref: ../components/schemas/poll.yaml
+          $ref: ../components/schemas/user.yaml
   responses:
     '201':
       description: Created
@@ -29,17 +29,11 @@ post:
             properties:
               id:
                 type: string
-                description: Id of the created poll.
+                description: Id of the created user.
       links:
-        get-poll:
-          $ref: ../components/links/get-poll.yaml
-        update-poll:
-          $ref: ../components/links/update-poll.yaml
-        delete-poll:
-          $ref: ../components/links/delete-poll.yaml
-        create-ballot:
-          $ref: ../components/links/create-ballot.yaml
-        list-poll-results:
-          $ref: ../components/links/list-poll-results.yaml
-    '400':
-      description: Bad Request. Expect at least 2 proposals and a title.
+        get-user:
+          $ref: ../components/links/get-user.yaml
+        update-user:
+          $ref: ../components/links/update-user.yaml
+        delete-user:
+          $ref: ../components/links/delete-user.yaml

--- a/openapi/paths/users.yaml
+++ b/openapi/paths/users.yaml
@@ -1,0 +1,45 @@
+get:
+  operationId: get-polls
+  summary: Gets all polls.
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: ../components/schemas/poll.yaml
+post:
+  operationId: create-poll
+  summary: Creates a poll.
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/poll.yaml
+  responses:
+    '201':
+      description: Created
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Id of the created poll.
+      links:
+        get-poll:
+          $ref: ../components/links/get-poll.yaml
+        update-poll:
+          $ref: ../components/links/update-poll.yaml
+        delete-poll:
+          $ref: ../components/links/delete-poll.yaml
+        create-ballot:
+          $ref: ../components/links/create-ballot.yaml
+        list-poll-results:
+          $ref: ../components/links/list-poll-results.yaml
+    '400':
+      description: Bad Request. Expect at least 2 proposals and a title.

--- a/openapi/paths/users.yaml
+++ b/openapi/paths/users.yaml
@@ -1,6 +1,6 @@
 get:
-  operationId: get-polls
-  summary: Gets all polls.
+  operationId: get-users
+  summary: Gets all users.
   responses:
     '200':
       description: OK
@@ -9,16 +9,16 @@ get:
           schema:
             type: array
             items:
-              $ref: ../components/schemas/poll.yaml
+              $ref: ../components/schemas/user.yaml
 post:
-  operationId: create-poll
-  summary: Creates a poll.
+  operationId: create-user
+  summary: Creates an user
   requestBody:
     required: true
     content:
       application/json:
         schema:
-          $ref: ../components/schemas/poll.yaml
+          $ref: ../components/schemas/user.yaml
   responses:
     '201':
       description: Created
@@ -29,17 +29,11 @@ post:
             properties:
               id:
                 type: string
-                description: Id of the created poll.
+                description: Id of the created user.
       links:
-        get-poll:
-          $ref: ../components/links/get-poll.yaml
-        update-poll:
-          $ref: ../components/links/update-poll.yaml
-        delete-poll:
-          $ref: ../components/links/delete-poll.yaml
-        create-ballot:
-          $ref: ../components/links/create-ballot.yaml
-        list-poll-results:
-          $ref: ../components/links/list-poll-results.yaml
-    '400':
-      description: Bad Request. Expect at least 2 proposals and a title.
+        get-user:
+          $ref: ../components/links/get-user.yaml
+        update-user:
+          $ref: ../components/links/update-user.yaml
+        delete-user:
+          $ref: ../components/links/delete-user.yaml

--- a/openapi/paths/users@{user-id}.yaml
+++ b/openapi/paths/users@{user-id}.yaml
@@ -1,0 +1,50 @@
+parameters:
+  - in: path
+    name: user-id
+    required: true
+    schema:
+      type: integer
+      format: int64
+get:
+  operationId: get-user
+  summary: Gets a user by ID
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/user.yaml
+    '404':
+      $ref: ../components/responses/user-not-found.yaml
+patch:
+  operationId: update-user
+  summary: Updates a user
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/user.yaml
+  security:
+    - {}
+    - userAuth: []
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: ../components/schemas/user.yaml
+delete:
+  operationId: delete-user
+  summary: Deletes a user
+  responses:
+    '200':
+      description: OK
+    '404':
+      $ref: ../components/responses/user-not-found.yaml
+  security:
+    - userAuth: []


### PR DESCRIPTION
This PR offers a new schema: user.

Users were thought first as an abstraction for any organizer. When a poll is created without any `user-id`, the back should create a dummy user.

But actually, we can extend the schema to any participant. In this case, we should clarify how to create a poll with optional participant.
 